### PR TITLE
Use newer ActiveRecord::Base.connection_db_config when available

### DIFF
--- a/lib/active_record/open_tracing/processor.rb
+++ b/lib/active_record/open_tracing/processor.rb
@@ -76,7 +76,9 @@ module ActiveRecord
       end
 
       def connection_config
-        @connection_config ||= ActiveRecord::Base.connection_config
+        # Rails 6.2 will deprecate ActiveRecord::Base.connection_config
+        @connection_config ||=
+          ActiveRecord::Base.try(:connection_db_config) || ActiveRecord::Base.connection_config
       end
     end
   end


### PR DESCRIPTION
Rails 6.2 will deprecate `ActiveRecord::Base.connection_config` in favor of `ActiveRecord::Base.connection_db_config`

This change should support both flavors in the meantime. `connection_db_config` was introduced in Rails 6.1

```
[1] pry(main)> ActiveRecord::Base.connection_config
DEPRECATION WARNING: connection_config is deprecated and will be removed from Rails 6.2 (Use connection_db_config instead) (called from <main> at (pry):1)
```