### PR TITLE
Fixed query tagging for empty queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+## 0.5.2 01/24/2022
+  * Fixed query tagging for empty queries
+
 ## 0.5.1 01/20/2022
   * Fixed the publishing process
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## 0.5.2.pre 01/24/2022
+## 0.5.2 01/24/2022
   * Fixed query tagging for empty queries
 
 ## 0.5.1 01/20/2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## 0.5.2 01/24/2022
+## 0.5.2.pre 01/24/2022
   * Fixed query tagging for empty queries
 
 ## 0.5.1 01/20/2022

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activerecord-instrumentation (0.5.1)
+    activerecord-instrumentation (0.5.2.pre)
       activerecord
       opentracing (~> 0.5)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activerecord-instrumentation (0.5.2.pre)
+    activerecord-instrumentation (0.5.2)
       activerecord
       opentracing (~> 0.5)
 

--- a/lib/active_record/open_tracing/processor.rb
+++ b/lib/active_record/open_tracing/processor.rb
@@ -87,7 +87,7 @@ module ActiveRecord
       def db_statement(payload)
         if sql_logging_enabled
           query_sql = sanitize_sql(payload.fetch(:sql).squish)
-          first_word = query_sql.split.first.downcase
+          first_word = query_sql.split.first&.downcase || ""
 
           {
             "db.statement" => query_sql,

--- a/lib/active_record/open_tracing/version.rb
+++ b/lib/active_record/open_tracing/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module OpenTracing
-    VERSION = "0.5.2.pre"
+    VERSION = "0.5.2"
   end
 end

--- a/lib/active_record/open_tracing/version.rb
+++ b/lib/active_record/open_tracing/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module OpenTracing
-    VERSION = "0.5.1"
+    VERSION = "0.5.2.pre"
   end
 end


### PR DESCRIPTION
In some cases, active record generates queries that return nil when you split on spaces.